### PR TITLE
FEAT: Install corsheaders and add in settings.py #19

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -137,9 +137,9 @@ REST_FRAMEWORK = {
 
 AUTH_USER_MODEL="usuario.Usuario"
 
-CORS_ALLOWED_ORIGINS = [
-    "http://localhost:5173",
-    "http://127.0.0.1:5173",
-]
+# CORS_ALLOWED_ORIGINS = [
+#     "http://localhost:5173",
+#     "http://127.0.0.1:5173",
+# ]
 CORS_ALLOW_CREDENTIALS = True
 CORS_ALLOW_ALL_ORIGINS = True


### PR DESCRIPTION
## pricipal 
- Install corsheaders --> ```pip install django-cors-headers```
- Add in INSTALLED_APPS --> ```'corsheaders',```


## more
```
CORS_ALLOWED_ORIGINS = [
    "http://localhost:5173",
    "http://127.0.0.1:5173",
]
CORS_ALLOW_CREDENTIALS = True
```